### PR TITLE
feat: surface ENS example as clickable suggestion below lookup input (ZK-1442)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -63,6 +63,11 @@
   color: var(--text);
 }
 
+.nav-cta:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* New button styles for better visual hierarchy */
 .btn {
   display: inline-flex;

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -9,6 +9,72 @@ import { ThemeToggle } from "../components/ThemeToggle";
 import { NameCard } from "../components/NameCard";
 import { colorForName } from "../utils/color";
 
+const EXAMPLE_NAME = "lajos.eth";
+
+function LookupForm({
+  value,
+  onChange,
+  onSubmit,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  onSubmit: (name: string) => void;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        gap: 8,
+        marginTop: 12,
+      }}
+    >
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          const name = value.trim();
+          if (name) onSubmit(name);
+        }}
+        style={{ display: "flex", gap: 8 }}
+      >
+        <input
+          className="input"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder="name.eth"
+          style={{ maxWidth: 240 }}
+        />
+        <button
+          className="nav-cta"
+          type="submit"
+          disabled={!value.trim()}
+        >
+          View
+        </button>
+      </form>
+      <p className="muted" style={{ margin: 0, fontSize: "0.9em" }}>
+        Try an example:{" "}
+        <button
+          type="button"
+          onClick={() => onSubmit(EXAMPLE_NAME)}
+          style={{
+            background: "none",
+            border: "none",
+            padding: 0,
+            font: "inherit",
+            color: "inherit",
+            textDecoration: "underline",
+            cursor: "pointer",
+          }}
+        >
+          {EXAMPLE_NAME}
+        </button>
+      </p>
+    </div>
+  );
+}
+
 export function HomePage() {
   const { address, isConnected } = useAccount();
   const { data: ensName } = useEnsName({
@@ -156,36 +222,13 @@ export function HomePage() {
               )}
               <div style={{ marginTop: 32 }}>
                 <p className="subtitle">or look up another ENS name</p>
-                <form
-                  onSubmit={(e) => {
-                    e.preventDefault();
-                    const name = lookupName.trim();
-                    if (name) {
-                      navigate(`/name/${name}`, { state: { from: "home" } });
-                    }
-                  }}
-                  style={{
-                    display: "flex",
-                    gap: 8,
-                    marginTop: 12,
-                    justifyContent: "center",
-                  }}
-                >
-                  <input
-                    className="input"
-                    value={lookupName}
-                    onChange={(e) => setLookupName(e.target.value)}
-                    placeholder="lajos.eth"
-                    style={{ maxWidth: 240 }}
-                  />
-                  <button
-                    className="nav-cta"
-                    type="submit"
-                    disabled={!lookupName.trim()}
-                  >
-                    View
-                  </button>
-                </form>
+                <LookupForm
+                  value={lookupName}
+                  onChange={setLookupName}
+                  onSubmit={(name) =>
+                    navigate(`/name/${name}`, { state: { from: "home" } })
+                  }
+                />
               </div>
             </>
           ) : (
@@ -198,36 +241,13 @@ export function HomePage() {
               </div>
               <div style={{ marginTop: 32 }}>
                 <p className="subtitle">or look up an ENS name</p>
-                <form
-                  onSubmit={(e) => {
-                    e.preventDefault();
-                    const name = lookupName.trim();
-                    if (name) {
-                      navigate(`/name/${name}`, { state: { from: "home" } });
-                    }
-                  }}
-                  style={{
-                    display: "flex",
-                    gap: 8,
-                    marginTop: 12,
-                    justifyContent: "center",
-                  }}
-                >
-                  <input
-                    className="input"
-                    value={lookupName}
-                    onChange={(e) => setLookupName(e.target.value)}
-                    placeholder="lajos.eth"
-                    style={{ maxWidth: 240 }}
-                  />
-                  <button
-                    className="nav-cta"
-                    type="submit"
-                    disabled={!lookupName.trim()}
-                  >
-                    View
-                  </button>
-                </form>
+                <LookupForm
+                  value={lookupName}
+                  onChange={setLookupName}
+                  onSubmit={(name) =>
+                    navigate(`/name/${name}`, { state: { from: "home" } })
+                  }
+                />
               </div>
             </>
           )}


### PR DESCRIPTION
Fixes [ZK-1442](https://linear.app/zk-email/issue/ZK-1442).

## Summary

- Replace the `lajos.eth` **placeholder** with a real clickable suggestion below the input: `Try an example: lajos.eth`. Clicking the chip navigates to `/name/lajos.eth`. The input itself now has a neutral `name.eth` placeholder. This makes the affordance explicit and stops the form from looking like it has a pre-filled value that's mysteriously not searchable.
- The View button stays correctly `disabled` until the user types — that was always the intent, but `.nav-cta` had no `:disabled` style so the button visually looked enabled. Added `.nav-cta:disabled { opacity: 0.5; cursor: not-allowed; }` (matches the existing `.input[disabled]` convention).
- The previous lookup form was duplicated between the connected and disconnected branches of `HomePage.tsx`. Extracted into a single `LookupForm` component used in both, with `const EXAMPLE_NAME = "lajos.eth"` at module scope as a single source of truth.

## Test plan

- [x] `tsc -b` + `eslint` clean
- [x] Local dev: input placeholder is `name.eth`; View is visibly dimmed when empty; clicking the `lajos.eth` chip routes to the profile page
- [x] Verified in both wallet states (connected + disconnected)
- [x] Reviewer eyeball on the chip styling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an example button to quickly autofill the ENS name field
  * "View" button now disables when the lookup field is empty

* **Style**
  * Updated form placeholder text for clarity
  * Added visual styling for disabled button state

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zkemail/ens-dashboard/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->