### PR TITLE
feat: URL-param prefill for ens.zk.email deep links

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,8 +1,8 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ConnectKitButton } from "connectkit";
 import { useAccount, useEnsName } from "wagmi";
 import { sepolia } from "wagmi/chains";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { useEnsNamesForAddress } from "../hooks/useEnsNames";
 import { NavBar } from "../components/NavBar";
 import { ThemeToggle } from "../components/ThemeToggle";
@@ -97,6 +97,26 @@ export function HomePage() {
   const [showSubdomains, setShowSubdomains] = useState(false);
   const [lookupName, setLookupName] = useState("");
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  // Deep-link entry: external tools (e.g. the Discord verification bot) can
+  // link to https://ens.zk.email?ens=<name>&platform=<key>&handle=<value>.
+  // Redirect to the profile page, forwarding the platform/handle params so
+  // ProfilePage can prefill the matching record row.
+  useEffect(() => {
+    const ens = searchParams.get("ens");
+    if (!ens) return;
+    const forwarded = new URLSearchParams();
+    const platform = searchParams.get("platform");
+    const handle = searchParams.get("handle");
+    if (platform) forwarded.set("platform", platform);
+    if (handle) forwarded.set("handle", handle);
+    const qs = forwarded.toString();
+    navigate(`/name/${ens}${qs ? `?${qs}` : ""}`, {
+      replace: true,
+      state: { from: "deeplink" },
+    });
+  }, [searchParams, navigate]);
 
   const { initialList, remainingSubdomains, subdomainCount } = useMemo(() => {
     const all = [...(ownedNames ?? [])].filter(Boolean);

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -1,10 +1,16 @@
-import { useParams, useNavigate, useLocation } from "react-router-dom";
-import { useEffect, useRef, useState } from "react";
+import {
+  useParams,
+  useNavigate,
+  useLocation,
+  useSearchParams,
+} from "react-router-dom";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useAccount } from "wagmi";
 import { NavBar } from "../components/NavBar";
 import { ThemeToggle } from "../components/ThemeToggle";
-import { RecordsList } from "../sections/RecordsList";
+import { RecordsList, type InitialPrefill } from "../sections/RecordsList";
 import { colorForName } from "../utils/color";
+import { resolvePlatformKey } from "../utils/prefillParams";
 import {
   PENDING_OAUTH_PROOF_KEY,
   type PendingOAuthProof,
@@ -16,8 +22,15 @@ export function ProfilePage() {
   const { ensName = "" } = useParams();
   const navigate = useNavigate();
   const location = useLocation() as { state?: { from?: string } };
+  const [searchParams] = useSearchParams();
   const { isConnected } = useAccount();
-  const [editing, setEditing] = useState(false);
+  const initialPrefill = useMemo<InitialPrefill | undefined>(() => {
+    const platformKey = resolvePlatformKey(searchParams.get("platform"));
+    const handle = searchParams.get("handle");
+    if (!platformKey || !handle) return undefined;
+    return { platformKey, handle };
+  }, [searchParams]);
+  const [editing, setEditing] = useState(Boolean(initialPrefill));
   const [pendingOAuthProof, setPendingOAuthProof] =
     useState<PendingOAuthProof | null>(null);
   const hasUnsaved = useRef(false);
@@ -118,6 +131,7 @@ export function ProfilePage() {
             onDirtyStateChange={(dirty) => (hasUnsaved.current = dirty)}
             pendingOAuthProof={pendingOAuthProof}
             onConsumePendingOAuthProof={() => setPendingOAuthProof(null)}
+            initialPrefill={initialPrefill}
           />
         </section>
       </main>

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -6,6 +6,7 @@ import {
 } from "react-router-dom";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useAccount } from "wagmi";
+import { ConnectKitButton, useModal } from "connectkit";
 import { NavBar } from "../components/NavBar";
 import { ThemeToggle } from "../components/ThemeToggle";
 import { RecordsList, type InitialPrefill } from "../sections/RecordsList";
@@ -24,6 +25,7 @@ export function ProfilePage() {
   const location = useLocation() as { state?: { from?: string } };
   const [searchParams] = useSearchParams();
   const { isConnected } = useAccount();
+  const { setOpen: setConnectModalOpen } = useModal();
   const initialPrefill = useMemo<InitialPrefill | undefined>(() => {
     const platformKey = resolvePlatformKey(searchParams.get("platform"));
     const handle = searchParams.get("handle");
@@ -31,6 +33,17 @@ export function ProfilePage() {
     return { platformKey, handle };
   }, [searchParams]);
   const [editing, setEditing] = useState(Boolean(initialPrefill));
+
+  // Deep-link arrivals (with a prefilled record from an external tool like
+  // the Discord verification bot) need a wallet to save records. Auto-open
+  // the ConnectKit modal once so they're not dead-ended on a page with no
+  // visible connect entry point.
+  const promptedConnectRef = useRef(false);
+  useEffect(() => {
+    if (!initialPrefill || isConnected || promptedConnectRef.current) return;
+    promptedConnectRef.current = true;
+    setConnectModalOpen(true);
+  }, [initialPrefill, isConnected, setConnectModalOpen]);
   const [pendingOAuthProof, setPendingOAuthProof] =
     useState<PendingOAuthProof | null>(null);
   const hasUnsaved = useRef(false);
@@ -66,6 +79,7 @@ export function ProfilePage() {
         right={
           <>
             <ThemeToggle />
+            <ConnectKitButton />
             {location.state?.from === "home" && (
               <button className="nav-cta" onClick={() => navigate(-1)}>
                 Back
@@ -90,9 +104,20 @@ export function ProfilePage() {
           </div>
 
           {!isConnected && (
-            <p className="subtitle" style={{ textAlign: "center" }}>
-              Connect your wallet to load resolver records.
-            </p>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                gap: 12,
+                marginTop: 12,
+              }}
+            >
+              <p className="subtitle" style={{ textAlign: "center", margin: 0 }}>
+                Connect your wallet to load resolver records.
+              </p>
+              <ConnectKitButton />
+            </div>
           )}
 
           <div

--- a/src/sections/RecordsList.tsx
+++ b/src/sections/RecordsList.tsx
@@ -16,18 +16,25 @@ import { placeholderForKey } from "../features/records/placeholders";
 import { getPlatform } from "../config/platforms";
 import { useProof } from "../features/proving/useProof";
 
+export type InitialPrefill = {
+  platformKey: RecordKey;
+  handle: string;
+};
+
 export function RecordsList({
   name,
   editing = false,
   onDirtyStateChange,
   pendingOAuthProof,
   onConsumePendingOAuthProof,
+  initialPrefill,
 }: {
   name: string;
   editing?: boolean;
   onDirtyStateChange?: (hasChanges: boolean) => void;
   pendingOAuthProof?: PendingOAuthProof | null;
   onConsumePendingOAuthProof?: () => void;
+  initialPrefill?: InitialPrefill;
 }) {
   const itemHandles = useRef<Record<RecordKey, RecordItemHandle | null>>(
     {} as Record<RecordKey, RecordItemHandle | null>,
@@ -39,6 +46,17 @@ export function RecordsList({
   useEffect(() => {
     onDirtyStateChange?.(dirtyKeys.size > 0);
   }, [dirtyKeys, onDirtyStateChange]);
+
+  const appliedPrefillRef = useRef(false);
+  useEffect(() => {
+    if (!initialPrefill || appliedPrefillRef.current) return;
+    if (!editing) return;
+    const handle = itemHandles.current[initialPrefill.platformKey];
+    if (!handle) return;
+    appliedPrefillRef.current = true;
+    handle.setDraft(initialPrefill.handle);
+    handle.scrollIntoView();
+  }, [editing, initialPrefill, dirtyKeys]);
 
   const onDirtyChange = (key: RecordKey, isDirty: boolean) => {
     setDirtyKeys((prev) => {
@@ -140,6 +158,8 @@ type RecordItemHandle = {
   resetDraft: () => void;
   hasChanges: () => boolean;
   isSaving: () => boolean;
+  setDraft: (value: string) => void;
+  scrollIntoView: () => void;
 };
 
 type RecordItemProps = {
@@ -234,6 +254,8 @@ const RecordItem = forwardRef<RecordItemHandle, RecordItemProps>(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [pendingOAuthProof]);
 
+    const liRef = useRef<HTMLLIElement>(null);
+
     useImperativeHandle(ref, () => ({
       async saveIfDirty() {
         if (isUnchanged || isPending || isConfirming) return false;
@@ -249,13 +271,19 @@ const RecordItem = forwardRef<RecordItemHandle, RecordItemProps>(
       isSaving() {
         return Boolean(isPending || isConfirming);
       },
+      setDraft(value: string) {
+        onChange(value);
+      },
+      scrollIntoView() {
+        liRef.current?.scrollIntoView({ behavior: "smooth", block: "center" });
+      },
     }));
 
     const viewValue = originalValue;
     if (!editing && !viewValue) return null;
 
     return (
-      <li className="name-card">
+      <li className="name-card" ref={liRef}>
         <div className="record-grid">
           <div className="record-label">{label}</div>
 

--- a/src/utils/prefillParams.ts
+++ b/src/utils/prefillParams.ts
@@ -1,0 +1,24 @@
+import { PLATFORM_BY_KEY } from "../config/platforms";
+import type { RecordKey } from "../config/platforms";
+
+/**
+ * Maps short, user-friendly platform names (used in deep links from external
+ * tools like the Discord verification bot) to internal record keys.
+ *
+ * Also accepts the fully-qualified key directly (e.g. "com.discord"), so links
+ * can use either form.
+ */
+const FRIENDLY_PLATFORM_ALIASES: Record<string, RecordKey> = {
+  discord: "com.discord",
+  twitter: "com.twitter",
+  x: "com.twitter",
+  github: "com.github",
+  telegram: "org.telegram",
+};
+
+export function resolvePlatformKey(raw: string | null): RecordKey | null {
+  if (!raw) return null;
+  const lowered = raw.toLowerCase();
+  if (PLATFORM_BY_KEY.has(lowered)) return lowered as RecordKey;
+  return FRIENDLY_PLATFORM_ALIASES[lowered] ?? null;
+}


### PR DESCRIPTION
## Summary
- Adds URL query-param support so external tools (e.g. the Discord verification bot) can deep-link users straight to the relevant platform record with a handle pre-filled.
- `?ens=<name>` on the root redirects to `/name/<name>` and forwards `platform` + `handle` params.
- `/name/<ens>?platform=<key>&handle=<value>` auto-enters edit mode, scrolls to the matching record, and pre-fills the input.
- Friendly platform aliases (`discord`, `twitter`/`x`, `github`, `telegram`) resolve to internal keys via a tiny alias table.
- Adds `ConnectKitButton` to the profile page's NavBar and surfaces an inline Connect button + auto-popping ConnectKit modal when a user arrives via deep link without a wallet connected. Without this, deep-link arrivals were dead-ended on a page with no visible wallet-connect entry point.

## Linear
[ZK-1448](https://linear.app/zk-email/issue/ZK-1448) — parent [ZK-1446](https://linear.app/zk-email/issue/ZK-1446).

## Test plan
- [ ] Open \`http://localhost:5173/?ens=vitalik.eth&platform=discord&handle=vitalik\` — redirects to \`/name/vitalik.eth?platform=discord&handle=vitalik\`, auto-enters editing mode, scrolls Discord row into view, prefills "vitalik".
- [ ] Same with \`platform=com.discord\` (full key) — still resolves.
- [ ] Same with \`platform=x\` or \`platform=twitter\` — both map to \`com.twitter\`.
- [ ] Open the profile URL with no params — behaves exactly as before.
- [ ] Disconnect wallet, then open a deep-link URL — ConnectKit modal auto-opens once; inline Connect button is visible below the "Connect your wallet to load resolver records" hint; NavBar Connect button works too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deep-linking support from external tools, allowing users to arrive at profiles and records with pre-filled information via URL parameters.
  * Automatically prompts wallet connection when users arrive via deep-links without a connected wallet.
  * Pre-fills form fields based on incoming URL parameters for seamless data entry.

* **UI/UX**
  * Enhanced wallet connection UI with improved layout and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->