### PR TITLE
feat: guided /verify flow for Discord-bot deep links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,14 @@ import { HomePage } from "./pages/HomePage";
 import { ProfilePage } from "./pages/ProfilePage";
 import { BenchmarkPage } from "./pages/BenchmarkPage";
 import { AuthCallbackPage } from "./pages/AuthCallbackPage";
+import { VerifyPage } from "./pages/VerifyPage";
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<HomePage />} />
       <Route path="/name/:ensName" element={<ProfilePage />} />
+      <Route path="/verify" element={<VerifyPage />} />
       <Route path="/benchmark" element={<BenchmarkPage />} />
       <Route path="/auth/callback" element={<AuthCallbackPage />} />
     </Routes>

--- a/src/components/ProofModal.tsx
+++ b/src/components/ProofModal.tsx
@@ -78,6 +78,8 @@ export interface ProofModalProps {
   blueprintSlug?: string;
   /** Gmail search query for OAuth (e.g. from:info@x.com subject:"Password reset request") */
   gmailQuery?: string;
+  /** Path to return to after OAuth completes. Defaults to `/name/<ensName>`. */
+  oauthReturnPath?: string;
 }
 
 function friendlyError(raw: string): string {
@@ -132,6 +134,7 @@ export function ProofModal({
   platformKey,
   blueprintSlug,
   gmailQuery,
+  oauthReturnPath,
 }: ProofModalProps) {
   const {
     isLoading,
@@ -369,7 +372,7 @@ export function ProofModal({
                 sessionStorage.setItem(OAUTH_PLATFORM_KEY, platformKey!);
                 sessionStorage.setItem(
                   OAUTH_RETURN_PATH_KEY,
-                  `/name/${encodeURIComponent(ensName)}`,
+                  oauthReturnPath ?? `/name/${encodeURIComponent(ensName)}`,
                 );
                 const callbackUrl = `${window.location.origin}/auth/callback`;
                 const params = new URLSearchParams({

--- a/src/components/ProofModal.tsx
+++ b/src/components/ProofModal.tsx
@@ -148,14 +148,38 @@ export function ProofModal({
     reset,
   } = hook;
 
-  const [useGoogleAuth, setUseGoogleAuth] = useState(false);
-  const [file, setFile] = useState<File | null>(null);
-  const [isDragOver, setIsDragOver] = useState(false);
+  // Touch-only devices (phones, tablets without a real file manager) can't
+  // realistically get a .eml file out of Gmail/iOS Mail/Outlook mobile, so
+  // the .eml drop zone is dead UI for them. We force Google-only there.
+  const [isTouchOnly, setIsTouchOnly] = useState(() =>
+    typeof window === "undefined"
+      ? false
+      : window.matchMedia("(pointer: coarse)").matches,
+  );
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mq = window.matchMedia("(pointer: coarse)");
+    const handler = (e: MediaQueryListEvent) => setIsTouchOnly(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
   const showGoogleOption = canUseGoogleSignIn({
     platformKey,
     blueprintSlug,
     gmailQuery,
   } as ProofModalProps);
+  const [useGoogleAuth, setUseGoogleAuth] = useState(
+    isTouchOnly && showGoogleOption,
+  );
+  const [file, setFile] = useState<File | null>(null);
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  // When viewport switches to touch-only mid-session (or we initially mounted
+  // before matchMedia settled), default to Google if available.
+  useEffect(() => {
+    if (isTouchOnly && showGoogleOption) setUseGoogleAuth(true);
+  }, [isTouchOnly, showGoogleOption]);
   const [progress, setProgress] = useState(0);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const startRef = useRef<number | null>(null);
@@ -172,7 +196,7 @@ export function ProofModal({
     if (!open) return;
     if (!result) reset();
     setFile(null);
-    setUseGoogleAuth(false);
+    setUseGoogleAuth(isTouchOnly && showGoogleOption);
     setIsDragOver(false);
     setProgress(0);
     startRef.current = null;
@@ -242,7 +266,11 @@ export function ProofModal({
       open={open}
       onClose={handleClose}
       canClose={!isBusy}
-      title={`Prove ${platformName} handle from email (.eml)`}
+      title={
+        isTouchOnly && showGoogleOption
+          ? `Prove ${platformName} handle via Gmail`
+          : `Prove ${platformName} handle from email (.eml)`
+      }
       footer={
         <>
           <button className="link-cta" onClick={handleClose}>
@@ -321,10 +349,24 @@ export function ProofModal({
         ) : null}
         <ol className="help-text" style={{ margin: 0, paddingLeft: 18 }}>
           <li>Request a password reset email from {platformName}.</li>
-          <li>In your email client, download the email as .eml or sign in with Google.</li>
-          <li>Drop the .eml here or choose Sign in with Google below.</li>
+          {isTouchOnly && showGoogleOption ? (
+            <li>
+              Sign in with Google below. We'll find the email and generate a
+              proof automatically.
+            </li>
+          ) : (
+            <>
+              <li>
+                In your email client, download the email as .eml — or sign in
+                with Google.
+              </li>
+              <li>
+                Drop the .eml here, or choose Sign in with Google below.
+              </li>
+            </>
+          )}
         </ol>
-        {showGoogleOption ? (
+        {showGoogleOption && !isTouchOnly ? (
           <div style={{ display: "flex", gap: 8, marginBottom: 8 }}>
             <button
               type="button"

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -14,6 +14,12 @@ export const PENDING_OAUTH_PROOF_KEY = "pending_oauth_proof";
 export interface PendingOAuthProof {
   platform: string;
   result: unknown;
+  /**
+   * The URL path the OAuth flow was initiated from. Consumers can compare
+   * this to their current location to reject stale entries that belong to a
+   * different verification flow (different ENS, handle, etc.).
+   */
+  returnPath?: string;
 }
 
 interface BackendProofResponse {
@@ -123,7 +129,7 @@ export function AuthCallbackPage() {
         const result = transformBackendProof(data.proof, data.publicInputs);
         sessionStorage.setItem(
           PENDING_OAUTH_PROOF_KEY,
-          JSON.stringify({ platform, result }),
+          JSON.stringify({ platform, result, returnPath }),
         );
         sessionStorage.removeItem(OAUTH_RETURN_PATH_KEY);
         sessionStorage.removeItem(OAUTH_PLATFORM_KEY);

--- a/src/pages/VerifyPage.css
+++ b/src/pages/VerifyPage.css
@@ -1,0 +1,216 @@
+/* Guided verify flow page — mobile-first.
+ *
+ * The page is built for users arriving from external deep links (e.g. the
+ * Discord verification bot) who have one specific intent. Single-column,
+ * full-width controls, touch-friendly tap targets.
+ */
+
+.verify-flow {
+  max-width: 560px;
+  padding-top: 24px;
+  padding-bottom: 48px;
+}
+
+.verify-context {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 24px;
+  text-align: center;
+}
+
+.verify-context-eyebrow {
+  font-size: 0.85em;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted, #6b7280);
+}
+
+.verify-context-title {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+  line-height: 1.3;
+  word-break: break-word;
+}
+
+.verify-context-title strong {
+  font-weight: 700;
+}
+
+/* Step indicator */
+.verify-steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  margin-bottom: 32px;
+  position: relative;
+}
+
+.verify-steps::before {
+  /* horizontal track */
+  content: "";
+  position: absolute;
+  top: 12px;
+  left: 16%;
+  right: 16%;
+  height: 2px;
+  background: var(--border);
+  z-index: 0;
+}
+
+.verify-step-pip {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  position: relative;
+  z-index: 1;
+}
+
+.verify-step-dot {
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  border: 2px solid var(--border);
+  background: var(--background, #0b1020);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--muted, #6b7280);
+  transition: all 200ms ease;
+}
+
+.verify-step-pip[data-state="active"] .verify-step-dot {
+  border-color: #60a5fa;
+  background: #60a5fa;
+  color: white;
+}
+
+.verify-step-pip[data-state="done"] .verify-step-dot {
+  border-color: #16a34a;
+  background: #16a34a;
+  color: white;
+}
+
+.verify-step-label {
+  font-size: 0.8rem;
+  color: var(--muted, #6b7280);
+  text-align: center;
+}
+
+.verify-step-pip[data-state="active"] .verify-step-label,
+.verify-step-pip[data-state="done"] .verify-step-label {
+  color: var(--text);
+  font-weight: 500;
+}
+
+/* Step content card */
+.verify-card {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: var(--card, transparent);
+}
+
+.verify-card-title {
+  font-size: 1.15rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.verify-card-body {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--text);
+  margin: 0;
+}
+
+.verify-card-body .muted {
+  color: var(--muted, #6b7280);
+}
+
+.verify-details {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 16px;
+  row-gap: 8px;
+  font-size: 0.95rem;
+}
+
+.verify-details dt {
+  color: var(--muted, #6b7280);
+  font-weight: 500;
+}
+
+.verify-details dd {
+  margin: 0;
+  font-weight: 600;
+  word-break: break-all;
+}
+
+.verify-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.verify-actions .nav-cta,
+.verify-actions .link-cta {
+  min-height: 44px;
+  width: 100%;
+  font-size: 1rem;
+  justify-content: center;
+}
+
+.verify-error {
+  padding: 16px;
+  border: 1px solid #ef4444;
+  border-radius: 8px;
+  color: #ef4444;
+  font-size: 0.95rem;
+}
+
+.verify-success {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  text-align: center;
+  padding: 8px 0;
+}
+
+.verify-success-icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: #16a34a;
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  font-weight: 700;
+}
+
+/* Slightly wider gutter on larger screens for visual balance */
+@media (min-width: 640px) {
+  .verify-flow {
+    padding-top: 40px;
+  }
+  .verify-actions {
+    flex-direction: row;
+    justify-content: flex-end;
+  }
+  .verify-actions .nav-cta,
+  .verify-actions .link-cta {
+    width: auto;
+    min-width: 160px;
+  }
+}

--- a/src/pages/VerifyPage.tsx
+++ b/src/pages/VerifyPage.tsx
@@ -1,0 +1,343 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useSearchParams, useNavigate } from "react-router-dom";
+import { useAccount } from "wagmi";
+import { ConnectKitButton, useModal } from "connectkit";
+import { NavBar } from "../components/NavBar";
+import { ThemeToggle } from "../components/ThemeToggle";
+import { ProofModal } from "../components/ProofModal";
+import { useProof } from "../features/proving/useProof";
+import { getPlatform } from "../config/platforms";
+import { resolvePlatformKey } from "../utils/prefillParams";
+import {
+  PENDING_OAUTH_PROOF_KEY,
+  type PendingOAuthProof,
+} from "./AuthCallbackPage";
+import "./VerifyPage.css";
+
+type Step = "connect" | "confirm" | "verify" | "done";
+
+const STEP_ORDER: Step[] = ["connect", "confirm", "verify"];
+const STEP_LABELS: Record<Step, string> = {
+  connect: "Connect",
+  confirm: "Confirm",
+  verify: "Verify",
+  done: "Done",
+};
+
+function StepIndicator({ current }: { current: Step }) {
+  const activeIndex =
+    current === "done" ? STEP_ORDER.length : STEP_ORDER.indexOf(current);
+  return (
+    <div className="verify-steps" role="list" aria-label="Verification steps">
+      {STEP_ORDER.map((step, i) => {
+        const state =
+          i < activeIndex ? "done" : i === activeIndex ? "active" : "pending";
+        return (
+          <div
+            key={step}
+            className="verify-step-pip"
+            data-state={state}
+            role="listitem"
+          >
+            <div className="verify-step-dot" aria-hidden>
+              {state === "done" ? "✓" : i + 1}
+            </div>
+            <span className="verify-step-label">{STEP_LABELS[step]}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function MissingParamsCard() {
+  return (
+    <section className="container verify-flow">
+      <div className="verify-card">
+        <h2 className="verify-card-title">Missing verification details</h2>
+        <p className="verify-card-body muted">
+          This page expects URL parameters from a Discord bot or similar tool
+          (e.g.{" "}
+          <code>?ens=vitalik.eth&amp;platform=discord&amp;handle=vitalik</code>).
+          If you got here directly, head back to the homepage and pick an ENS
+          name from there.
+        </p>
+        <div className="verify-actions">
+          <a className="nav-cta" href="/">
+            Back to home
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ShortAddress({ value }: { value: string }) {
+  if (value.length <= 10) return <>{value}</>;
+  return (
+    <>
+      {value.slice(0, 6)}…{value.slice(-4)}
+    </>
+  );
+}
+
+export function VerifyPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const { isConnected, address } = useAccount();
+  const { setOpen: setConnectModalOpen } = useModal();
+
+  const ensName = searchParams.get("ens")?.trim().toLowerCase() || "";
+  const handle = searchParams.get("handle")?.trim() || "";
+  const platformKey = resolvePlatformKey(searchParams.get("platform"));
+  const platform = useMemo(
+    () => (platformKey ? getPlatform(platformKey) : undefined),
+    [platformKey],
+  );
+
+  const proofHook = useProof(
+    platform ?? {
+      key: "noop",
+      label: "",
+      placeholder: "",
+      verifiable: false,
+    },
+  );
+
+  const [step, setStep] = useState<Step>(isConnected ? "confirm" : "connect");
+  const [proofModalOpen, setProofModalOpen] = useState(false);
+
+  // Auto-advance from connect step once the wallet is connected.
+  useEffect(() => {
+    setStep((current) => {
+      if (current === "connect" && isConnected) return "confirm";
+      return current;
+    });
+  }, [isConnected]);
+
+  // Move to the done step once the on-chain submission is confirmed.
+  useEffect(() => {
+    if (proofHook.hasSubmitted) {
+      setStep("done");
+      setProofModalOpen(false);
+    }
+  }, [proofHook.hasSubmitted]);
+
+  // Auto-pop the connect modal once on mount when not connected — saves a tap.
+  const promptedConnectRef = useRef(false);
+  useEffect(() => {
+    if (!platform || isConnected || promptedConnectRef.current) return;
+    promptedConnectRef.current = true;
+    setConnectModalOpen(true);
+  }, [platform, isConnected, setConnectModalOpen]);
+
+  // Pick up a pending OAuth proof when returning from Google sign-in. Same
+  // pattern as ProfilePage. We jump straight to the proof modal so the user
+  // can review and submit on-chain without re-uploading anything.
+  const consumedOAuthRef = useRef(false);
+  useEffect(() => {
+    if (consumedOAuthRef.current) return;
+    if (!platform) return;
+    const raw = sessionStorage.getItem(PENDING_OAUTH_PROOF_KEY);
+    if (!raw) return;
+    try {
+      const parsed = JSON.parse(raw) as PendingOAuthProof;
+      if (parsed?.platform !== platform.key) return;
+      sessionStorage.removeItem(PENDING_OAUTH_PROOF_KEY);
+      consumedOAuthRef.current = true;
+      const r = parsed.result as Record<string, unknown> | null;
+      const proofProps =
+        r && typeof r === "object"
+          ? ((r.proof as Record<string, unknown> | undefined)?.props as
+              | Record<string, unknown>
+              | undefined)
+          : undefined;
+      if (!proofProps?.proofData || !Array.isArray(proofProps?.publicOutputs)) {
+        return;
+      }
+      proofHook.setResult?.(
+        parsed.result as { proof: unknown; verification: unknown },
+      );
+      setStep("verify");
+      setProofModalOpen(true);
+    } catch {
+      sessionStorage.removeItem(PENDING_OAUTH_PROOF_KEY);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [platform]);
+
+  if (!ensName || !platform || !handle || !platform.verifiable) {
+    return (
+      <>
+        <NavBar
+          right={
+            <>
+              <ThemeToggle />
+              <ConnectKitButton />
+            </>
+          }
+        />
+        <main>
+          <MissingParamsCard />
+        </main>
+      </>
+    );
+  }
+
+  const oauthReturnPath = `/verify?${searchParams.toString()}`;
+
+  return (
+    <>
+      <NavBar
+        right={
+          <>
+            <ThemeToggle />
+            <ConnectKitButton />
+          </>
+        }
+      />
+      <main>
+        <section className="container verify-flow">
+          <header className="verify-context">
+            <span className="verify-context-eyebrow">
+              Verify {platform.label} handle
+            </span>
+            <h1 className="verify-context-title">
+              <strong>{handle}</strong> on <strong>{ensName}</strong>
+            </h1>
+          </header>
+
+          <StepIndicator current={step} />
+
+          {step === "connect" && (
+            <div className="verify-card">
+              <h2 className="verify-card-title">Connect your wallet</h2>
+              <p className="verify-card-body">
+                Connect the wallet that owns{" "}
+                <strong>{ensName}</strong>. You'll use it to sign the on-chain
+                transaction that records this verification.
+              </p>
+              <div className="verify-actions">
+                <ConnectKitButton />
+              </div>
+            </div>
+          )}
+
+          {step === "confirm" && (
+            <div className="verify-card">
+              <h2 className="verify-card-title">Confirm details</h2>
+              <dl className="verify-details">
+                <dt>ENS name</dt>
+                <dd>{ensName}</dd>
+                <dt>Platform</dt>
+                <dd>{platform.label}</dd>
+                <dt>Handle</dt>
+                <dd>{handle}</dd>
+                <dt>Wallet</dt>
+                <dd>
+                  {address ? <ShortAddress value={address} /> : "—"}
+                </dd>
+              </dl>
+              <p className="verify-card-body muted">
+                Make sure the connected wallet owns <strong>{ensName}</strong>.
+                If not, switch wallets via the connect button above.
+              </p>
+              <div className="verify-actions">
+                <button
+                  type="button"
+                  className="link-cta"
+                  onClick={() => setStep("connect")}
+                >
+                  Change wallet
+                </button>
+                <button
+                  type="button"
+                  className="nav-cta"
+                  onClick={() => {
+                    setStep("verify");
+                    setProofModalOpen(true);
+                  }}
+                >
+                  Continue
+                </button>
+              </div>
+            </div>
+          )}
+
+          {step === "verify" && (
+            <div className="verify-card">
+              <h2 className="verify-card-title">
+                Prove ownership of {handle}
+              </h2>
+              <p className="verify-card-body">
+                We need a ZK proof that you control the {platform.label} account{" "}
+                <strong>{handle}</strong>. The simplest path is to sign in with
+                Google so we can find the {platform.label} password-reset email
+                automatically — or you can upload a <code>.eml</code> file
+                manually.
+              </p>
+              <div className="verify-actions">
+                <button
+                  type="button"
+                  className="link-cta"
+                  onClick={() => setStep("confirm")}
+                >
+                  Back
+                </button>
+                <button
+                  type="button"
+                  className="nav-cta"
+                  onClick={() => setProofModalOpen(true)}
+                >
+                  {proofHook.result ? "Continue verification" : "Start verification"}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {step === "done" && (
+            <div className="verify-card">
+              <div className="verify-success">
+                <div className="verify-success-icon" aria-hidden>
+                  ✓
+                </div>
+                <h2 className="verify-card-title">Verified!</h2>
+                <p className="verify-card-body">
+                  <strong>{handle}</strong> is now linked to{" "}
+                  <strong>{ensName}</strong> with a ZK proof.
+                </p>
+                <p className="verify-card-body muted">
+                  Head back to Discord and run{" "}
+                  <code>/verify {ensName}</code> again to claim your role.
+                </p>
+              </div>
+              <div className="verify-actions">
+                <button
+                  type="button"
+                  className="link-cta"
+                  onClick={() => navigate(`/name/${ensName}`)}
+                >
+                  View profile
+                </button>
+              </div>
+            </div>
+          )}
+        </section>
+      </main>
+
+      <ProofModal
+        open={proofModalOpen}
+        onClose={() => setProofModalOpen(false)}
+        ensName={ensName}
+        platformName={platform.label}
+        estimatedDurationMs={platform.estimatedProveDurationMs ?? 60_000}
+        buildCommand={platform.buildCommand ?? (() => "")}
+        hook={proofHook}
+        platformKey={platform.key}
+        blueprintSlug={platform.blueprintSlug}
+        gmailQuery={platform.gmailQuery}
+        oauthReturnPath={oauthReturnPath}
+      />
+    </>
+  );
+}

--- a/src/pages/VerifyPage.tsx
+++ b/src/pages/VerifyPage.tsx
@@ -107,13 +107,42 @@ export function VerifyPage() {
   const [step, setStep] = useState<Step>(isConnected ? "confirm" : "connect");
   const [proofModalOpen, setProofModalOpen] = useState(false);
 
-  // Auto-advance from connect step once the wallet is connected.
+  // Track the active flow context so we can reset state when the user
+  // navigates from one /verify URL to a different one in the same tab —
+  // otherwise a stale hasSubmitted=true or pending OAuth result from the
+  // previous flow leaks into the new one.
+  const contextKey = `${ensName}|${handle}|${platformKey ?? ""}`;
+  const lastContextRef = useRef(contextKey);
+
+  const promptedConnectRef = useRef(false);
+  const consumedOAuthRef = useRef(false);
+
+  // Auto-advance into / demote out of the verify flow as the wallet state
+  // changes. A disconnect mid-flow must demote — the confirm/verify cards
+  // require a signer the user no longer has.
   useEffect(() => {
+    if (!isConnected) setProofModalOpen(false);
     setStep((current) => {
-      if (current === "connect" && isConnected) return "confirm";
+      if (isConnected && current === "connect") return "confirm";
+      if (!isConnected && (current === "confirm" || current === "verify"))
+        return "connect";
       return current;
     });
   }, [isConnected]);
+
+  // When the user navigates to a different /verify URL without unmounting
+  // (e.g. SPA navigation to a new ENS/handle/platform), drop any in-flight
+  // proof state and reopen the wallet prompt if needed.
+  useEffect(() => {
+    if (lastContextRef.current === contextKey) return;
+    lastContextRef.current = contextKey;
+    proofHook.reset();
+    consumedOAuthRef.current = false;
+    promptedConnectRef.current = false;
+    setStep(isConnected ? "confirm" : "connect");
+    setProofModalOpen(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [contextKey, isConnected]);
 
   // Move to the done step once the on-chain submission is confirmed.
   useEffect(() => {
@@ -124,27 +153,34 @@ export function VerifyPage() {
   }, [proofHook.hasSubmitted]);
 
   // Auto-pop the connect modal once on mount when not connected — saves a tap.
-  const promptedConnectRef = useRef(false);
   useEffect(() => {
     if (!platform || isConnected || promptedConnectRef.current) return;
     promptedConnectRef.current = true;
     setConnectModalOpen(true);
   }, [platform, isConnected, setConnectModalOpen]);
 
-  // Pick up a pending OAuth proof when returning from Google sign-in. Same
-  // pattern as ProfilePage. We jump straight to the proof modal so the user
-  // can review and submit on-chain without re-uploading anything.
-  const consumedOAuthRef = useRef(false);
+  // Pick up a pending OAuth proof when returning from Google sign-in.
+  //
+  // Two gates beyond platform-match:
+  //  - Require a connected wallet. Without a signer the Submit button in
+  //    ProofModal can't do anything; auto-advancing to the verify step would
+  //    dead-end the user. We hold the entry until the wallet is connected,
+  //    then consume on the same re-run.
+  //  - Match the persisted `returnPath` against our current /verify URL.
+  //    A stale entry from a prior session (different ENS or handle) belongs
+  //    to that other flow; we preserve it so it can be consumed when the
+  //    user navigates back to the matching URL.
   useEffect(() => {
     if (consumedOAuthRef.current) return;
-    if (!platform) return;
+    if (!platform || !isConnected) return;
     const raw = sessionStorage.getItem(PENDING_OAUTH_PROOF_KEY);
     if (!raw) return;
+    const expectedReturnPath = `/verify?${searchParams.toString()}`;
     try {
       const parsed = JSON.parse(raw) as PendingOAuthProof;
       if (parsed?.platform !== platform.key) return;
-      sessionStorage.removeItem(PENDING_OAUTH_PROOF_KEY);
-      consumedOAuthRef.current = true;
+      if (parsed?.returnPath && parsed.returnPath !== expectedReturnPath)
+        return;
       const r = parsed.result as Record<string, unknown> | null;
       const proofProps =
         r && typeof r === "object"
@@ -153,8 +189,11 @@ export function VerifyPage() {
               | undefined)
           : undefined;
       if (!proofProps?.proofData || !Array.isArray(proofProps?.publicOutputs)) {
+        sessionStorage.removeItem(PENDING_OAUTH_PROOF_KEY);
         return;
       }
+      sessionStorage.removeItem(PENDING_OAUTH_PROOF_KEY);
+      consumedOAuthRef.current = true;
       proofHook.setResult?.(
         parsed.result as { proof: unknown; verification: unknown },
       );
@@ -164,7 +203,7 @@ export function VerifyPage() {
       sessionStorage.removeItem(PENDING_OAUTH_PROOF_KEY);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [platform]);
+  }, [platform, isConnected, searchParams]);
 
   if (!ensName || !platform || !handle || !platform.verifiable) {
     return (
@@ -246,7 +285,7 @@ export function VerifyPage() {
                 <button
                   type="button"
                   className="link-cta"
-                  onClick={() => setStep("connect")}
+                  onClick={() => setConnectModalOpen(true)}
                 >
                   Change wallet
                 </button>

--- a/src/utils/prefillParams.ts
+++ b/src/utils/prefillParams.ts
@@ -1,0 +1,25 @@
+import { PLATFORM_BY_KEY } from "../config/platforms";
+import type { RecordKey } from "../config/platforms";
+
+/**
+ * Maps short, user-friendly platform names (used in deep links from external
+ * tools like the Discord verification bot) to internal record keys.
+ *
+ * Also accepts the fully-qualified key directly (e.g. "com.discord"), so links
+ * can use either form.
+ */
+const FRIENDLY_PLATFORM_ALIASES: Record<string, RecordKey> = {
+  discord: "com.discord",
+  twitter: "com.twitter",
+  x: "com.twitter",
+  github: "com.github",
+  telegram: "org.telegram",
+};
+
+export function resolvePlatformKey(raw: string | null): RecordKey | null {
+  if (!raw) return null;
+  const lowered = raw.trim().toLowerCase();
+  if (!lowered) return null;
+  if (PLATFORM_BY_KEY.has(lowered)) return lowered as RecordKey;
+  return FRIENDLY_PLATFORM_ALIASES[lowered] ?? null;
+}


### PR DESCRIPTION
## Summary
- New mobile-first guided page at `/verify?ens=<X>&platform=<Y>&handle=<Z>`. Three steps: Connect wallet → Confirm details → Verify (proof). Built for users arriving from external deep links (e.g. the Discord verification bot) who have one specific intent.
- Reuses the existing `ProofModal` so .eml upload, Gmail OAuth, progress bar, and on-chain submission are unchanged for desktop.
- `ProofModal` gains an optional `oauthReturnPath` prop so Gmail OAuth bounces back to `/verify?...` instead of hardcoded `/name/<ens>`.
- VerifyPage picks up pending OAuth proofs from sessionStorage on mount (same pattern as ProfilePage) and jumps straight to the proof modal.
- Mobile (`pointer: coarse`) detection in `ProofModal` forces Google sign-in only, hides the .eml/Google tab switcher, and rewrites the instructions and modal title to omit `.eml` mentions — phone email apps don't expose `.eml` exports so the drop zone was dead UI.
- Mobile-friendly CSS in `VerifyPage.css`: single-column, full-width controls, ≥44px touch targets, compact horizontal step indicator.
- New `src/utils/prefillParams.ts` resolves friendly platform names (`discord`, `twitter`/`x`, `github`, `telegram`) to record keys.

## Linear
[ZK-1449](https://linear.app/zk-email/issue/ZK-1449) — parent [ZK-1446](https://linear.app/zk-email/issue/ZK-1446).

Note: #23 was closed; its `prefillParams.ts` (with CodeRabbit's trim fix) is the only piece carried forward into this PR.

## Test plan
- [ ] Desktop, wallet disconnected: open \`/verify?ens=vitalik.eth&platform=discord&handle=vitalik\`. ConnectKit modal auto-opens once; both .eml + Google options visible in proof modal.
- [ ] Desktop, wallet connected: same URL skips connect step, lands on Confirm. Continue → Verify modal opens with both options.
- [ ] Mobile viewport (or Chrome devtools "Responsive" + Touch enabled): same URL. \`.eml\` tab + drop zone hidden; only Google sign-in visible; title says "via Gmail".
- [ ] Gmail OAuth path: sign in with Google, complete redirect — should return to \`/verify?...\` (not \`/name/...\`), proof injected, modal re-opens, Submit on-chain works.
- [ ] Missing params (e.g. \`/verify\` with nothing): friendly "missing details" card with link back home.
- [ ] Done step shows after \`hasSubmitted\` flips; copy tells user to return to Discord and re-run \`/verify <ens>\`.

## Known issues (from self-review + CodeRabbit, to address in follow-ups)
- VerifyPage 'Change wallet' button no-ops while still connected — needs disconnect+open flow.
- `consumedOAuthRef` doesn't cross-check ENS/handle of the OAuth payload — stale entry from a prior session could be replayed.
- OAuth-pickup effect can advance to step=verify even when wallet is not connected — needs an isConnected guard.
- `RecordItem` OAuth-shape validation also accepts crafted sessionStorage entries (pre-existing in ProfilePage path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)