### PR TITLE
fix: read resolver from ENS Registry directly (setText broken on Sepolia post-ENSv2)

### DIFF
--- a/src/features/records/abi.ts
+++ b/src/features/records/abi.ts
@@ -4,6 +4,10 @@ export const setTextAbi = parseAbi([
   "function setText(bytes32 node,string key,string value)",
 ]);
 
+export const ensRegistryAbi = parseAbi([
+  "function resolver(bytes32 node) view returns (address)",
+]);
+
 export const textRecordVerifierAbi = parseAbi([
   "function verifyTextRecord(bytes32 node,string key,string value) view returns (bool)",
 ]);

--- a/src/features/records/useRecordText.ts
+++ b/src/features/records/useRecordText.ts
@@ -1,6 +1,5 @@
 import {
   useAccount,
-  useEnsResolver,
   useEnsText,
   useReadContract,
   useWaitForTransactionReceipt,
@@ -12,14 +11,20 @@ import { useEffect, useMemo, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import type { RecordKey } from "../../config/platforms";
 import { normalizeValueForKey, validateValueForKey } from "./validators";
-import { setTextAbi, textRecordVerifierAbi } from "./abi";
+import { ensRegistryAbi, setTextAbi, textRecordVerifierAbi } from "./abi";
 import { CONTRACTS } from "../../config/contracts";
 import { VERIFY_COMMAND_ENDPOINT } from "../../config/env";
 import { getPlatform, isPlatformVerifiable } from "../../config/platforms";
 
+/**
+ * Canonical ENS Registry address. Deployed deterministically at the same
+ * address on mainnet, Sepolia, and most testnets where ENS is active.
+ */
+const ENS_REGISTRY_ADDRESS =
+  "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e" as const;
+
 export function useRecordText(name: string, key: RecordKey) {
   const { chainId } = useAccount();
-  const { data: resolver } = useEnsResolver({ name, chainId });
   const { data, isLoading, refetch } = useEnsText({ name, key, chainId });
 
   const [draft, setDraft] = useState<string | undefined>(undefined);
@@ -48,6 +53,27 @@ export function useRecordText(name: string, key: RecordKey) {
   }, [key, platform]);
 
   const node = useMemo(() => namehash(name), [name]);
+
+  // Resolve the resolver address by reading the ENS Registry directly.
+  //
+  // We deliberately do NOT use wagmi's `useEnsResolver` here: that hook
+  // routes through the UniversalResolver, and on Sepolia (post-ENSv2
+  // rollout, ~May 2026) the UniversalResolver returns a read-only fallback
+  // resolver (`ENSV1Resolver`) for legacy v1 names. Writing `setText` to
+  // that fallback reverts — the function doesn't exist.
+  //
+  // The Registry's resolver pointer remains the writable PublicResolver
+  // for every legacy name (and is what new write-capable resolvers will
+  // be registered against going forward), so it's the correct write target.
+  const { data: resolver } = useReadContract({
+    address: ENS_REGISTRY_ADDRESS,
+    abi: ensRegistryAbi,
+    functionName: "resolver",
+    args: [node],
+    chainId,
+    query: { enabled: Boolean(name) },
+  });
+
   const { data: verifiedData, isLoading: isVerifying } = useReadContract({
     address: verifierAddress,
     abi: textRecordVerifierAbi,


### PR DESCRIPTION
## Symptom

Clicking **Save** on any record at \`/name/<ens>\` on Sepolia causes MetaMask to refuse to submit (\"transaction likely to fail\" / \"gas limit too high\"). The decoded tx targets \`0x422484c2D51f92830bFB563fa5e172aa2D8B884b\`, which is a verified read-only \`ENSV1Resolver\` contract — no \`setText\` function. eth_call simulation reverts.

## Forensic findings on \`lajos.eth\` (namehash \`0x93f8a11e…11644\`)

| Check | Source | Result |
|---|---|---|
| \`ENSRegistry.resolver(node)\` | direct read | **\`0x8FADE66B79cC9f707aB26799354482EB93a5B7dD\`** (writable PublicResolver, set 2025-09-29, never changed since) |
| \`useEnsResolver\` via UniversalResolver | wagmi | \`0x422484c2D51f92830bFB563fa5e172aa2D8B884b\` (read-only ENSv1 fallback, deployed ~May 26, 2026) |
| \`eth_call setText(…)\` on \`0x8FADE6…\` from owner wallet | viem simulation | **succeeds** |
| \`eth_call setText(…)\` on \`0x422484…\` | viem simulation | **reverts (no such function)** |

Sepolia ENSv2's new UniversalResolver moved out from under us — wagmi's \`useEnsResolver\` now resolves to a read-only fallback for legacy v1 names. This affects every Sepolia ENS user.

## The fix

Replace \`useEnsResolver\` with a direct \`useReadContract\` against the ENS Registry's \`resolver(bytes32)\` function. The Registry is deployed at the same address on mainnet and Sepolia (\`0x000…2E1E\`), so the change is chain-agnostic and doesn't require any new config.

\`useEnsResolver\` is semantically for the **read** path — what to query records *from*. Writes need the **registry-level** resolver pointer, which is what \`setText\` is authorized against. We were using the wrong hook for the job.

## Why not just upgrade wagmi/viem?

- Already on \`wagmi ^2.17\`, \`viem 2.x\` — both recent.
- The issue isn't a wagmi bug. wagmi's \`useEnsResolver\` consistently returns whatever the UniversalResolver tells it to. That contract's behavior changed upstream; upgrading wagmi keeps using the same broken pattern.

Other options (capability detection via \`supportsInterface\`, UniversalResolver address override, hardcoding per-chain) were considered and rejected — see [ZK-1451](https://linear.app/zk-email/issue/ZK-1451) for the comparison.

## Test plan

- [ ] Connect the wallet that owns \`lajos.eth\` (\`0x1f81d6…D88d\`) on Sepolia.
- [ ] Open \`/name/lajos.eth\`, edit the Email or URL record, click Save.
- [ ] MetaMask shows a real gas estimate (no \"likely to fail\"). Transaction succeeds.
- [ ] Refresh — value persists on-chain.
- [ ] Verified-checkmark behavior on the Discord row unchanged (read path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)